### PR TITLE
Made the authentication links go away only after logging in

### DIFF
--- a/present-registry/src/assets/styles/AuthenticationModal.css
+++ b/present-registry/src/assets/styles/AuthenticationModal.css
@@ -7,7 +7,7 @@
 .login-form h2 {
     margin: 0 0 15px;
 }
-.form-control, .btn {
+.form-control .btn {
     min-height: 38px;
     border-radius: 2px;
 }
@@ -43,7 +43,7 @@ a.loginBtn:hover{
 .register-form h2 {
     margin: 0 0 15px;
 }
-.form-control, .btn {
+.form-control .btn {
     min-height: 38px;
     border-radius: 2px;
 }

--- a/present-registry/src/assets/styles/NavBar.css
+++ b/present-registry/src/assets/styles/NavBar.css
@@ -29,9 +29,10 @@ h1.navbar-brand:hover{
 }
 
 .subItem{
-      color:  #FFFFFC !important;
-      text-decoration: none !important;
-      font-size: 100% !important;
+      padding: 10px;
+      font-size: 100%;
+      color: white !important;
+      font-weight: 500;
 }
 
 .nav-link{

--- a/present-registry/src/components/ModalLogin.vue
+++ b/present-registry/src/components/ModalLogin.vue
@@ -12,7 +12,7 @@
                         <input type="password" class="form-control" placeholder="Password" required="required" v-model="password">
                     </div>
                     <div class="form-group">
-                        <button type="submit" class="btn btn-primary btn-block">Log in</button>
+                        <button type="submit" class="btn btn-primary btn-block" @click="$emit('authenticated')" >Log in</button>
                     </div>
                     <div class="text-sm font-normal text-center">
                         <p>Don't have an account? <a href="#" class="text-blue-600 hover:text-blue-800" @click.prevent="showRegister" @keydown.tab.exact.prevent="">Register</a></p>

--- a/present-registry/src/components/ModalRegister.vue
+++ b/present-registry/src/components/ModalRegister.vue
@@ -3,7 +3,7 @@
         <a href="#register" @click.prevent="show" class="registerBtn" @click="showModal = true">Register</a>
         <modal name="modal-register" :height="420">
             <div class="register-form">
-                <form action="#" method="post">
+                <form action="#" method="">
                     <h2 class="text-center">Register</h2>       
                     <div class="form-group">
                         <input type="text" class="form-control" placeholder="Name" required="required">

--- a/present-registry/src/components/NavBar.vue
+++ b/present-registry/src/components/NavBar.vue
@@ -13,13 +13,22 @@
           <li class="nav-item">
           </li>
         </ul>
-        <div class="authentication-modals">
+        <div  v-if="!authenticated" class="authentication-modals">
           <span class="navbar-text">
-            <ModalLogin/>
+            <ModalLogin v-on:authenticated="authenticateSwitch"/>
           </span>
           <span>|</span>
           <span class="navbar-text">
             <ModalRegister/>
+          </span>
+        </div>
+        <div v-if="authenticated" class="signed-in ">
+          <span class="navbar-text ">
+            Hello, {{username}}
+          </span>
+          <span>|</span>
+          <span class="navbar-text">
+            <button @click="authenticateSwitch" type="button" class="btn signout-btn">Sign Out</button>
           </span>
         </div>
       </div>
@@ -37,10 +46,35 @@ export default {
     ModalLogin,
     ModalRegister
   },
+  data() {
+    return {
+      authenticated: false,
+      username: "John"
+    }
+  }, 
+  methods: {
+    authenticateSwitch() {
+      if(this.authenticated)
+        this.authenticated = false;
+      else
+        this.authenticated = true;
+    }
+  }
     
 }
 </script>
 
 <style>
     @import '../assets/styles/NavBar.css';
+
+    .signed-in span{
+      padding: 10px;
+      font-size: 150%;
+      color: white !important;
+      font-weight: 700;
+    }
+
+    .signout-btn{
+      background-color: white!important;
+    }
 </style>


### PR DESCRIPTION
I added a the variables authenticated and username in the navbar component. authenticated is the conditional variable that will determine the state of the authentication display on the navbar.

username is hardcoded now to "John", but will be dynamic when we get the api connected.

in the navbar, there is an authenticateSwitch() method that is called when the Login button in the login modal is pressed or when the Signout button is pressed.